### PR TITLE
Fix: Display full chart history instead of sliding window

### DIFF
--- a/nextjs/app/page.tsx
+++ b/nextjs/app/page.tsx
@@ -1284,7 +1284,7 @@ export default function ThemeParkSimulator() {
             satisfactionMax: params.satisfactionMax,
           },
         ]
-        // return newHistory.slice(-100) // Removed to show all history
+        
         return newHistory
       })
 


### PR DESCRIPTION
Modified the updateSimulation function in `nextjs/app/page.tsx` to remove the `.slice(-100)` call when updating `statsHistory`.

This change ensures that the chart retains and displays all data points from the beginning of the simulation, effectively de-zooming over time as more data is added, rather than showing a fixed-size sliding window of the most recent data.